### PR TITLE
Enhance card draw interface with fantasy theme and animations

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,58 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Roboto&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background: radial-gradient(circle at top, #1b2735, #090a0f);
+  color: #f8f9fa;
+  min-height: 100vh;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Cinzel', serif;
+  color: #ffd700;
+}
+
+.btn-primary {
+  background-color: #6f42c1;
+  border-color: #6f42c1;
+}
+
+.btn-primary:hover {
+  background-color: #59359a;
+  border-color: #59359a;
+}
+
+.card-wrapper {
+  perspective: 1000px;
+}
+
+.draw-card {
+  opacity: 0;
+  transform: translateY(-50px) rotateY(90deg);
+  transition: transform 0.8s ease, opacity 0.8s ease;
+  transform-style: preserve-3d;
+  background-color: #1e1e2f;
+  border: 2px solid #ffd700;
+  box-shadow: 0 0 15px rgba(255, 215, 0, 0.4);
+}
+
+.draw-card img {
+  border-bottom: 2px solid #ffd700;
+}
+
+.draw-card.revealed {
+  opacity: 1;
+  transform: translateY(0) rotateY(0deg);
+}
+
+.card-img-top {
+  max-height: 200px;
+  object-fit: cover;
+}
+.btn-link {
+  color: #ffd700;
+}
+.btn-link:hover {
+  color: #e6c200;
+}
+

--- a/static/js/draw.js
+++ b/static/js/draw.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cards = document.querySelectorAll('.draw-card');
+  cards.forEach((card, index) => {
+    setTimeout(() => {
+      card.classList.add('revealed');
+    }, index * 700);
+  });
+});

--- a/templates/draw.html
+++ b/templates/draw.html
@@ -7,11 +7,13 @@
   <div class="row justify-content-center">
     {% for card in cards %}
       <div class="col-12 col-sm-6 col-md-4 mb-4">
-        <div class="card shadow-sm h-100">
-          <img src="{{ card.image_url }}" class="card-img-top" alt="{{ card.name }}">
-          <div class="card-body text-center">
-            <h5 class="card-title">{{ card.name }}</h5>
-            <p class="card-text text-muted">{{ card.category }}</p>
+        <div class="card-wrapper">
+          <div class="card draw-card shadow-sm h-100">
+            <img src="{{ card.image_url }}" class="card-img-top" alt="{{ card.name }}">
+            <div class="card-body text-center">
+              <h5 class="card-title">{{ card.name }}</h5>
+              <p class="card-text">{{ card.category }}</p>
+            </div>
           </div>
         </div>
       </div>
@@ -21,4 +23,5 @@
     <a href="{{ url_for('index') }}" class="btn btn-secondary">Retour à l'accueil</a>
   </div>
 </div>
+<script src="{{ url_for('static', filename='js/draw.js') }}"></script>
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,8 +1,8 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="container py-5">
-  <h1 class="mb-4 text-center">Citadelle – Tirage de cartes</h1>
+  <div class="container py-5">
+    <h1 class="mb-4 text-center">Citadelle – Rituel de tirage</h1>
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
@@ -13,15 +13,15 @@
     {% endif %}
   {% endwith %}
   {% if user %}
-    <div class="text-center">
-      <p>Bienvenue, <strong>{{ user.username }}</strong> !</p>
-      <p>Vous pouvez effectuer un tirage de cartes une fois par jour. Chaque tirage vous attribue trois cartes aléatoires basées sur les mêmes données que le bot Discord.</p>
-      <a href="{{ url_for('draw') }}" class="btn btn-primary btn-lg">Tirer mes cartes</a>
-      <a href="{{ url_for('logout') }}" class="btn btn-link">Déconnexion</a>
-    </div>
-  {% else %}
-    <div class="text-center">
-      <p>Connectez-vous avec votre compte Discord pour commencer vos tirages journaliers.</p>
+      <div class="text-center">
+        <p>Bienvenue, <strong>{{ user.username }}</strong> !</p>
+        <p>Les esprits t'accordent un tirage quotidien. Chaque rituel dévoile trois cartes mystiques issues des mêmes arcanes que le bot Discord.</p>
+        <a href="{{ url_for('draw') }}" class="btn btn-primary btn-lg">Tirer mes cartes</a>
+        <a href="{{ url_for('logout') }}" class="btn btn-link">Déconnexion</a>
+      </div>
+    {% else %}
+      <div class="text-center">
+        <p>Connectez-vous avec votre compte Discord pour commencer vos tirages journaliers.</p>
       <a href="{{ url_for('login') }}" class="btn btn-success btn-lg">Se connecter avec Discord</a>
     </div>
   {% endif %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,15 +6,7 @@
   <title>Citadelle – Tirage de cartes</title>
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1qm3I1/2RZh8eOkhe4LyJ4GOPwwyI5Q6iQFTrbD2HwpGxygJZJlL9OlOxNJJ0ekp" crossorigin="anonymous">
-  <style>
-    body {
-      background-color: #f7f7f7;
-    }
-    .card-img-top {
-      max-height: 200px;
-      object-fit: cover;
-    }
-  </style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
   {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- Revamp layout to load a custom fantasy stylesheet and remove inline styles
- Animate card reveals with new JavaScript and sequential flip-in effects
- Introduce a darker, mystical theme and narrative text on the home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6898e7bd648c8323a8adeac91599a294