### PR TITLE
Handle SSL errors on Google Drive image fetch

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ import os
 import json
 import random
 import hashlib
+import ssl
 from datetime import datetime
 from functools import wraps
 from typing import List, Dict, Tuple, Optional, Any
@@ -38,6 +39,7 @@ from dotenv import load_dotenv
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 import gspread
+import requests
 
 ###############################################################################
 # Environment and application setup
@@ -802,7 +804,28 @@ def logout() -> Any:
 def card_image(file_id: str) -> Any:
     """Serve an image from Google Drive by file ID."""
     try:
-        file_data = drive_service.files().get_media(fileId=file_id).execute()
+        try:
+            file_data = drive_service.files().get_media(fileId=file_id).execute()
+        except ssl.SSLError as e:
+            app.logger.error(f"SSL error retrieving image {file_id}: {e}")
+            try:
+                mime_type = file_mime_types.get(file_id)
+                if not mime_type:
+                    meta = drive_service.files().get(fileId=file_id, fields="mimeType").execute()
+                    mime_type = meta.get("mimeType", "application/octet-stream")
+                    file_mime_types[file_id] = mime_type
+                url = f"https://drive.google.com/uc?export=download&id={file_id}"
+                r = requests.get(url, timeout=10, verify=not app.debug)
+                if r.status_code == 200:
+                    return Response(r.content, mimetype=mime_type)
+                app.logger.error(
+                    f"Fallback download failed for {file_id}: status {r.status_code}"
+                )
+            except Exception as fallback_err:
+                app.logger.error(
+                    f"Fallback error retrieving image {file_id}: {fallback_err}"
+                )
+            return ('', 404)
         mime_type = file_mime_types.get(file_id)
         if not mime_type:
             meta = drive_service.files().get(fileId=file_id, fields="mimeType").execute()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.0
 Authlib==1.2.1
 pytz==2023.3
 gunicorn==21.2.0
+requests==2.31.0


### PR DESCRIPTION
## Summary
- Retry Drive image fetch via public URL when SSL fails
- Add `requests` and SSL imports and dependency

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689998fff8608323a3e5779e8ef6662a